### PR TITLE
Fix test running

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -13,19 +13,12 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [14.x, 16.x, 18.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-
     steps:
-    - uses: actions/checkout@v3
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+    - uses: actions/setup-node@v3
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: 18
         cache: 'npm'
+        cache-dependency-path: subdir/package-lock.json
     - run: npm ci
     - run: npm run build --if-present
     - run: npm test

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -18,7 +18,7 @@ jobs:
       with:
         node-version: 18
         cache: 'npm'
-        cache-dependency-path: subdir/package-lock.json
+        cache-dependency-path: domain/package-lock.json
     - run: npm ci
     - run: npm run build --if-present
     - run: npm test


### PR DESCRIPTION
Fix issue with running Github action for tests, the problem was related with package-lock.json in the `domain` subdirectory since `domain` is a workspace, so it was failing because it could found the package-lock.json

I found the solution here: 
https://stackoverflow.com/questions/68639588/github-actions-dependencies-lock-file-is-not-found-in-runners-path

and more info in here:
https://github.com/actions/setup-node#caching-packages-dependencies